### PR TITLE
Fix hanging bargeable audio in SynthAndRecog

### DIFF
--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1671,6 +1671,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 #if AST_VERSION_AT_LEAST(11,0,0)
 					if (ast_channel_streamid(chan) == -1 && ast_channel_timingfunc(chan) == NULL) {
 						ast_stopstream(chan);
+						end_of_prompt = 1;
 						app_session->filestream = NULL;
 					}
 #else

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1671,6 +1671,7 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 #if AST_VERSION_AT_LEAST(11,0,0)
 					if (ast_channel_streamid(chan) == -1 && ast_channel_timingfunc(chan) == NULL) {
 						ast_stopstream(chan);
+						ast_log(LOG_DEBUG, "(%s) File is over\n", recog_name);
 						end_of_prompt = 1;
 						app_session->filestream = NULL;
 					}


### PR DESCRIPTION
## Issue

When SynthAndRecog() is invoked with an audio file and barge-in enabled on Asterisk >= 11, then START-INPUT-TIMERS is never sent out.

## Side-effects

As long as the caller is mute / does not provide input,

* It never advances past the 1st sound file because end_of_prompt is never true (similar symptom to #14).
* A no-input timeout can never occur because START-INPUT-TIMERS won't trigger until we have finished prompt_processing (which never gets set as complete as we are stuck with end_of_prompt == 0).

## Cause & Resolution
When a single audio file is complete, we were only setting `end_of_prompt = 1;` for Asterisk < 11.  This change simply applies that setting to the Asterisk >= 11 case as well.