### PR TITLE
Always stop barged tts

### DIFF
--- a/app-unimrcp/app_mrcpsynth.c
+++ b/app-unimrcp/app_mrcpsynth.c
@@ -459,6 +459,7 @@ static int mrcpsynth_exit(struct ast_channel *chan, app_session_t *app_session, 
 
 		if (app_session->synth_channel) {
 			if (app_session->lifetime == APP_SESSION_LIFETIME_DYNAMIC) {
+				speech_channel_stop(app_session->synth_channel);
 				speech_channel_destroy(app_session->synth_channel);
 				app_session->synth_channel = NULL;
 			}

--- a/app-unimrcp/app_synthandrecog.c
+++ b/app-unimrcp/app_synthandrecog.c
@@ -1272,6 +1272,7 @@ static int synthandrecog_exit(struct ast_channel *chan, app_session_t *app_sessi
 
 		if (app_session->lifetime == APP_SESSION_LIFETIME_DYNAMIC) {
 			if (app_session->synth_channel) {
+				speech_channel_stop(app_session->synth_channel);
 				speech_channel_destroy(app_session->synth_channel);
 				app_session->synth_channel = NULL;
 			}


### PR DESCRIPTION
In the case of some versions of NeoSpeech TTS, if it receives a [RTSP TEARDOWN](https://tools.ietf.org/html/rfc2326#page-37) without a preceding [MRCP STOP](https://tools.ietf.org/html/rfc4463#section-7.9) before it, then it does not release the licensed port.

This change ensures that the licensed TTS port is fully released by sending a [MRCP STOP](https://tools.ietf.org/html/rfc4463#section-7.9) prior to the [RTSP TEARDOWN](https://tools.ietf.org/html/rfc2326#page-37).

This is the _lazy_ but hopefully comprehensive approach to ensuring that the TTS channel is cleanly and fully stopped before sending a TEARDOWN.

I say "lazy", because this approach will inevitably cause `speech_channel_stop()` to be invoked twice in some cases.  However, this is completely innocuous in such cases, because [the method will exit much like a no-op if synth is not active, such as when the method has already been called](https://github.com/unispeech/asterisk-unimrcp/blob/asterisk-unimrcp-1.5.2/app-unimrcp/speech_channel.c#L554).
