### PR TITLE
set speech channel timeout to a more realistic value

### DIFF
--- a/app-unimrcp/ast_unimrcp_framework.c
+++ b/app-unimrcp/ast_unimrcp_framework.c
@@ -46,7 +46,7 @@
 #define DEFAULT_UNIMRCP_OFFER_NEW_CONNECTION   1
 #define DEFAULT_UNIMRCP_LOG_LEVEL              "DEBUG"
 
-#define DEFAULT_SPEECH_CHANNEL_TIMEOUT         apr_time_from_msec(30000)
+#define DEFAULT_SPEECH_CHANNEL_TIMEOUT         apr_time_from_msec(2000)
 
 #define DEFAULT_LOCAL_IP_ADDRESS               "127.0.0.1"
 #define DEFAULT_REMOTE_IP_ADDRESS              "127.0.0.1"


### PR DESCRIPTION
No one expects to wait 30 seconds for a response on their phone (because for example asterisk-unimrcp could not open a speech channel with the asr server). 
In the real world, users will abandon an unresponsive system long before that.
A more realistic approach would be to set a minimum timeout to 2 seconds (or 1 second) allowing the next commands or the dialplan or the agi script (or agi-java) to transfer the call.
This can go unnoticed even from very experienced developers (real case scenario) for years (because no one expects that the default value of the minimum timeout of a real time system will be  30 seconds )...

So, my suggestion is 2 seconds of minimum speech channel timeout.